### PR TITLE
feat: update ranking text

### DIFF
--- a/Assets/Scenes/PlayScene.unity
+++ b/Assets/Scenes/PlayScene.unity
@@ -351,7 +351,7 @@ MonoBehaviour:
   m_VertexBufferAutoSizeReduction: 0
   m_useMaxVisibleDescender: 1
   m_pageToDisplay: 1
-  m_margin: {x: 0, y: 0, z: -3.062561, w: -13.699707}
+  m_margin: {x: 0, y: 0, z: -204.1877, w: -13.699707}
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_hasFontAssetChanged: 0

--- a/Assets/Scripts/multiplayer/RaceStandings.cs
+++ b/Assets/Scripts/multiplayer/RaceStandings.cs
@@ -5,6 +5,8 @@ using PurrNet;
 using PurrNet.Packing;
 using TMPro;
 using UnityEngine;
+using UnityEngine.Localization;
+using UnityEngine.Localization.Settings;
 
 // Server-auth. Concatena tutti i RoadMeshGenerator in UNA SOLA spline (array flat di Vector3).
 // Per ogni PlayerIdentity nella scena, ogni updateRate secondi, scan globale dei punti spline ->
@@ -46,6 +48,19 @@ public class RaceStandings : NetworkBehaviour
 
     private int _lastLoggedRank = -1;
     private int _lastLoggedTotal = -1;
+
+    private void OnEnable()
+    {
+        LocalizationSettings.SelectedLocaleChanged += OnLocaleChanged;
+    }
+
+    private void OnLocaleChanged(Locale locale)
+    {
+        // Forza il refresh del testo al prossimo Update anche se rank/total non sono cambiati,
+        // così il suffisso ordinale si aggiorna subito se la lingua cambia a metà gara.
+        _lastLoggedRank = -1;
+    }
+
     void Update()
     {
         if (!isSpawned) return;
@@ -54,7 +69,34 @@ public class RaceStandings : NetworkBehaviour
         if (rank == _lastLoggedRank && total == _lastLoggedTotal) return;
         _lastLoggedRank = rank;
         _lastLoggedTotal = total;
-        localRankText.text = $"{rank}/{total}";
+
+        if (rank <= 0)
+        {
+            localRankText.text = $"-/{total}";
+            return;
+        }
+
+        string suffix = GetOrdinalSuffix(rank);
+        localRankText.text = $"{rank}<size=60%>{suffix}</size> / {total}";
+    }
+
+    private static string GetOrdinalSuffix(int n)
+    {
+        string localeCode = LocalizationSettings.SelectedLocale?.Identifier.Code ?? "en";
+
+        if (localeCode.StartsWith("it", StringComparison.OrdinalIgnoreCase))
+            return "°"; // Italiano: stesso indicatore ordinale per ogni numero
+
+        // Fallback inglese (copre anche "en" e qualsiasi locale non gestita)
+        int rem100 = n % 100;
+        if (rem100 >= 11 && rem100 <= 13) return "th";
+        return (n % 10) switch
+        {
+            1 => "st",
+            2 => "nd",
+            3 => "rd",
+            _ => "th"
+        };
     }
 
     void Awake()
@@ -64,6 +106,7 @@ public class RaceStandings : NetworkBehaviour
 
     private new void OnDestroy()
     {
+        LocalizationSettings.SelectedLocaleChanged -= OnLocaleChanged;
         if (_tickCo != null) StopCoroutine(_tickCo);
         if (Instance == this) Instance = null;
     }

--- a/Assets/Scripts/multiplayer/RaceStandings.cs
+++ b/Assets/Scripts/multiplayer/RaceStandings.cs
@@ -77,7 +77,7 @@ public class RaceStandings : NetworkBehaviour
         }
 
         string suffix = GetOrdinalSuffix(rank);
-        localRankText.text = $"{rank}<size=60%>{suffix}</size> / {total}";
+        localRankText.text = $"{rank}{suffix}/{total}";
     }
 
     private static string GetOrdinalSuffix(int n)
@@ -89,13 +89,13 @@ public class RaceStandings : NetworkBehaviour
 
         // Fallback inglese (copre anche "en" e qualsiasi locale non gestita)
         int rem100 = n % 100;
-        if (rem100 >= 11 && rem100 <= 13) return "th";
+        if (rem100 >= 11 && rem100 <= 13) return "<size=60%>th</size>";
         return (n % 10) switch
         {
-            1 => "st",
-            2 => "nd",
-            3 => "rd",
-            _ => "th"
+            1 => "<size=60%>st</size>",
+            2 => "<size=60%>nd</size>",
+            3 => "<size=60%>rd</size>",
+            _ => "<size=60%>th</size>"
         };
     }
 


### PR DESCRIPTION
## Aggiunge suffisso ordinale al contatore posizione (1° / 2° / 1st / 2nd...)

### Sommario
Il testo di posizione in `RaceStandings.cs` mostrava solo `rank/total` (es. `1/4`). Questa PR aggiunge il suffisso ordinale (`1st`, `2nd`, `3rd`, `4th`... in EN, `1°`, `2°`, `3°`... in IT) reso in formato più piccolo rispetto al numero principale, ed è già agganciato al sistema di localizzazione esistente.

### Modifiche
- **`GetOrdinalSuffix(int n)`**: nuovo metodo statico che calcola il suffisso ordinale corretto in base alla locale attiva (`LocalizationSettings.SelectedLocale`).
  - `it`: usa sempre `°`, coerentemente con le convenzioni italiane (1°, 2°, 3°...).
  - tutte le altre locale (default `en`): suffissi irregolari `st/nd/rd/th` con gestione corretta degli 11°/12°/13°.
- **`Update()`**: il testo viene ora composto come `{rank}<size=60%>{suffix}</size> / {total}`, usando il rich text di TextMeshPro per rendere il suffisso al 60% della dimensione del numero principale. Aggiunto anche un guard per `rank <= 0` (stato transitorio prima che il server calcoli il primo ranking), che mostra `-/{total}` invece di `0th/4`.
- **`OnEnable`/`OnLocaleChanged`**: sottoscrizione a `LocalizationSettings.SelectedLocaleChanged` (stesso pattern già usato in `LanguageSelector.cs`) per forzare l'aggiornamento del testo se il giocatore cambia lingua a metà gara, anche se il rank non cambia.
- **`OnDestroy`**: aggiunta la disiscrizione dall'evento di cambio locale per evitare leak/callback su oggetto distrutto.

### Note tecniche
- Nessuna modifica alla logica di calcolo del ranking (server-auth, `ComputeRanks`/`BuildFlatSpline` invariati).
- Richiede che **Rich Text** sia abilitato sul componente `TextMeshProUGUI` collegato a `localRankText` (è l'impostazione di default, ma va verificato in Inspector se il tag `<size>` non viene renderizzato).
- Il suffisso non è stato spostato nelle String Table di Localization (`ui`/`app`) perché si tratta di una regola di formattazione numerica, non di testo traducibile a parole — è gestito via branching sul codice locale, come `LanguageSelector.cs`.

### Test consigliati
- [ ] Avviare una gara, verificare che `1st/4`, `2nd/4` ecc. si mostrino correttamente in EN.
- [ ] Cambiare lingua in IT (anche durante la gara) e verificare che il suffisso diventi `°`.
- [ ] Verificare il rank `11°/12°/13°` in EN (caso speciale `th`).
- [ ] Verificare lo stato iniziale prima del primo calcolo dei rank (`-/4`).